### PR TITLE
[feat]장비 장착 컨트롤러 로직 구현 및 UI 동기화

### DIFF
--- a/Assets/LSH/LSH_Scenes/Test/LSH_Inventory.unity
+++ b/Assets/LSH/LSH_Scenes/Test/LSH_Inventory.unity
@@ -803,7 +803,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 754473925}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6e9b9ab388501544d809a86f1d5625d9, type: 3}
   m_Name: 
@@ -816,8 +816,8 @@ MonoBehaviour:
   detailBackgroundImage: {fileID: 1039249981}
   detailIcon: {fileID: 126877104}
   detailName: {fileID: 1997823994}
-  detailTraitIcon: {fileID: 0}
-  detailTraitName: {fileID: 0}
+  detailTraitIcon: {fileID: 1456664945}
+  detailTraitName: {fileID: 492017131}
   equipButton: {fileID: 193475839}
   unlockButton: {fileID: 1769651693}
   tooltipPanel: {fileID: 0}
@@ -1219,7 +1219,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &1039249980
 RectTransform:
   m_ObjectHideFlags: 0
@@ -1394,16 +1394,17 @@ MonoBehaviour:
   m_slotPrefab: {fileID: 2667497581635974875, guid: fdb4fa56a10156547a550fbedb88c30b, type: 3}
   m_emptySlotSprite: {fileID: 21300000, guid: ed1074391f139544d941ae0870937dc0, type: 3}
   m_detailPanel: {fileID: 1039249979}
-  m_detailIcon: {fileID: 126877104}
   m_detailBackgroundImage: {fileID: 1039249981}
+  m_detailIcon: {fileID: 126877104}
   m_detailName: {fileID: 1997823994}
-  m_detailDesc: {fileID: 2028844756}
+  m_detailTraitIcon: {fileID: 1456664945}
+  m_detailTraitName: {fileID: 492017131}
   m_equipButton: {fileID: 193475839}
   m_unlockButton: {fileID: 1769651693}
   m_detailBlocker: {fileID: 858328039}
-  m_tooltipPanel: {fileID: 0}
-  m_tooltipTraitName: {fileID: 0}
-  m_tooltipTraitDesc: {fileID: 0}
+  m_tooltipPanel: {fileID: 1137574852}
+  m_tooltipName: {fileID: 0}
+  m_tooltipDesc: {fileID: 0}
   m_mainCloseButton: {fileID: 944108772}
   m_detailCloseButton: {fileID: 1230474973}
 --- !u!1 &1137574852
@@ -1423,7 +1424,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &1137574853
 RectTransform:
   m_ObjectHideFlags: 0

--- a/Assets/LSH/LSH_Scripts/Inventory/InventoryEquipView.cs
+++ b/Assets/LSH/LSH_Scripts/Inventory/InventoryEquipView.cs
@@ -15,12 +15,19 @@ public class InventoryEquipView : MonoBehaviour
     [Header("Right Panel - Detail")]
     [SerializeField] private GameObject m_detailPanel;
     [SerializeField] private Image m_detailBackgroundImage;
-    [SerializeField] private Image m_detailIcon;             // 장비 아이콘
+
+    // 💡 [NEW] UI 스위칭용 그룹 변수
+    [Header("UI Groups")]
+    [SerializeField] private GameObject m_unlockedUIGroup; // 해금 시 켜지는 그룹 (아이콘, 이름, 특성 등 몽땅)
+    [SerializeField] private GameObject m_lockedUIGroup;   // 잠금 시 켜지는 그룹 (정중앙 안내 문구)
+
+    [Header("Unlocked UI Elements")]
+    [SerializeField] private Image m_detailIcon;
     [SerializeField] private TextMeshProUGUI m_detailName;
+    [SerializeField] private Image m_detailTraitIcon;
+    [SerializeField] private TextMeshProUGUI m_detailTraitName;
 
-    [SerializeField] private Image m_detailTraitIcon;        // 특성 아이콘
-    [SerializeField] private TextMeshProUGUI m_detailTraitName;  // 특성 이름 텍스트 (미해금 시 안내 문구로 활용)
-
+    [Header("Buttons")]
     [SerializeField] private Button m_equipButton;
     [SerializeField] private Button m_unlockButton;
     [SerializeField] private Button m_detailBlocker;
@@ -41,7 +48,7 @@ public class InventoryEquipView : MonoBehaviour
 
     private int m_currentViewedItemID = -1;
     private Color m_originalDetailColor;
-    private ItemData m_currentDetailItem; // 툴팁용 데이터 임시 저장
+    private ItemData m_currentDetailItem;
 
     private void Awake()
     {
@@ -60,7 +67,6 @@ public class InventoryEquipView : MonoBehaviour
 
         if (m_detailBackgroundImage != null) m_originalDetailColor = m_detailBackgroundImage.color;
 
-        // 💡 [듀얼 툴팁 연결] 장비(true)와 특성(false)에 각각 이벤트를 붙여줍니다.
         if (m_detailIcon != null) SetupTooltipTrigger(m_detailIcon.gameObject, true);
         if (m_detailTraitIcon != null) SetupTooltipTrigger(m_detailTraitIcon.gameObject, false);
 
@@ -77,9 +83,8 @@ public class InventoryEquipView : MonoBehaviour
         EventTrigger.Entry enter = new EventTrigger.Entry { eventID = EventTriggerType.PointerEnter };
         enter.callback.AddListener((data) => {
             if (m_tooltipPanel == null || m_currentDetailItem == null) return;
-            if (!m_currentDetailItem.isUnlocked) return; // 미해금 장비는 툴팁 안 띄움
+            if (!m_currentDetailItem.isUnlocked) return;
 
-            // 💡 [듀얼 툴팁 로직] 마우스가 올라간 대상에 맞춰 내용을 다르게 표시!
             if (isEquipment)
             {
                 if (m_tooltipName != null) m_tooltipName.text = m_currentDetailItem.name;
@@ -125,22 +130,14 @@ public class InventoryEquipView : MonoBehaviour
         m_detailPanel.SetActive(true);
         if (m_detailBlocker != null) m_detailBlocker.gameObject.SetActive(true);
 
-        // 📝 미해금 장비 처리
+        // 📝 미해금(잠금) 장비 처리
         if (!item.isUnlocked)
         {
             if (m_detailBackgroundImage != null) m_detailBackgroundImage.color = new Color(0.6f, 0.6f, 0.6f, 1f);
 
-            // 아이콘 및 이름 숨기기
-            if (m_detailName != null) m_detailName.gameObject.SetActive(false);
-            if (m_detailIcon != null) m_detailIcon.gameObject.SetActive(false);
-            if (m_detailTraitIcon != null) m_detailTraitIcon.gameObject.SetActive(false);
-
-            // 💡 [미해금 텍스트 수정] 특성 이름 텍스트 자리를 활용하여 해금 메시지 노출
-            if (m_detailTraitName != null)
-            {
-                m_detailTraitName.gameObject.SetActive(true);
-                m_detailTraitName.text = "<align=center><color=#55FF55>던전 해금 시\n착용 가능</color></align>";
-            }
+            // 💡 그룹 스위칭: 잠금 UI 켜고, 일반 UI 끄기
+            if (m_unlockedUIGroup != null) m_unlockedUIGroup.SetActive(false);
+            if (m_lockedUIGroup != null) m_lockedUIGroup.SetActive(true);
 
             if (m_equipButton != null) m_equipButton.gameObject.SetActive(false);
             if (m_unlockButton != null) m_unlockButton.gameObject.SetActive(true);
@@ -151,19 +148,14 @@ public class InventoryEquipView : MonoBehaviour
         {
             if (m_detailBackgroundImage != null) m_detailBackgroundImage.color = m_originalDetailColor;
 
-            if (m_detailName != null) { m_detailName.gameObject.SetActive(true); m_detailName.text = item.name; }
-            if (m_detailIcon != null) { m_detailIcon.gameObject.SetActive(true); m_detailIcon.sprite = item.icon; }
+            // 💡 그룹 스위칭: 일반 UI 켜고, 잠금 UI 끄기
+            if (m_unlockedUIGroup != null) m_unlockedUIGroup.SetActive(true);
+            if (m_lockedUIGroup != null) m_lockedUIGroup.SetActive(false);
 
-            if (m_detailTraitIcon != null)
-            {
-                m_detailTraitIcon.gameObject.SetActive(true);
-                m_detailTraitIcon.sprite = item.traitIcon;
-            }
-            if (m_detailTraitName != null)
-            {
-                m_detailTraitName.gameObject.SetActive(true);
-                m_detailTraitName.text = item.traitName;
-            }
+            if (m_detailName != null) m_detailName.text = item.name;
+            if (m_detailIcon != null) m_detailIcon.sprite = item.icon;
+            if (m_detailTraitIcon != null) m_detailTraitIcon.sprite = item.traitIcon;
+            if (m_detailTraitName != null) m_detailTraitName.text = item.traitName;
 
             if (m_equipButton != null) m_equipButton.gameObject.SetActive(true);
             if (m_unlockButton != null) m_unlockButton.gameObject.SetActive(false);


### PR DESCRIPTION

# 🧑‍💻 PR

## 🔗 관련 이슈
- Resolves: #이슈번호_여기에_작성

<br>

## 🔥 작업 내용 요약
1. **Feat** - 장비 장착 컨트롤러 로직 구현 (`InventoryEquipController` 연동)
2. **Feat** - 장비 장착 완료 시 UI 상태 즉각 동기화 (팝업 닫기 및 슬롯 갱신)

<br>

## 💻 작업 구현 방법 (공통)
### 📝 구현 설명
- **아이템 선택 상태 캐싱:** `InventoryEquipController` 내부에 `m_currentSelectedItemID` 변수를 추가하여, 유저가 인벤토리 슬롯을 클릭할 때 해당 아이템의 ID를 임시로 기억(캐싱)하도록 구현했습니다.
- **실제 장착 로직 연동:** 우측 상세 팝업창에서 '장착' 버튼을 누르면, 캐싱해둔 아이템 ID를 `DataManager`로 전달하여 실제 파티 장착 기능이 실행되도록 연결했습니다.
- **UX 및 UI 자동 갱신:** 장착 처리가 완료되면 기획 사양에 맞춰 열려있던 상세 팝업창을 자동으로 닫고, `RefreshUI`를 호출하여 전체 인벤토리 슬롯의 장착/미장착 상태가 화면에 즉시 동기화되도록 처리했습니다.

### ❓구현 의도
- **MVC 패턴 구조 강화:** UI 뷰단에서 직접 데이터를 조작하지 않고, Controller가 유저의 입력을 기억했다가 데이터 매니저에 명령을 내리도록 역할을 명확히 분리했습니다. 이를 통해 향후 로직 확장과 유지보수가 용이해집니다.

### 🔊 특이사항
- `InventoryEquipController.cs` 스크립트 내부에 상태를 기억하는 변수와 장착 이벤트 연결 로직이 크게 추가되었습니다.

<br>

## ✅ PR 체크리스트
- [x] 빌드 오류 없음
- [x] 기능 정상 작동 확인
- [x] 커밋 메시지 규칙 준수
- [x] Scene 충돌 없음

## 💬 기타 사항
- 컨트롤러를 통한 장비 장착 연동과 UI 새로고침 기능까지 모두 정상적으로 맞물려 돌아가는 것을 확인했습니다. 리뷰 부탁드립니다!